### PR TITLE
[add] Route config to individual routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.0
+
+- Individual routes now contain configuration settings under `config`,
+  similar to API.config.
+
 ## 0.8.0
 
 - Path template parsing now uses same logic as Hapi (sans wildcard routes)

--- a/src/__tests__/route.test.js
+++ b/src/__tests__/route.test.js
@@ -11,13 +11,11 @@ describe('route', function() {
       description: 'My API',
       baseURL: 'http://example.com'
     })
+    let read = { path: 'users' }
 
-    route(api, { users: { read: { path: 'users' } } })
+    route(api, { users: { read } })
 
-    api.users.read.config.should.have.property('path', 'users')
-
-    for (var i in api.config) {
-      api.users.read.config.should.have.property(i, api.config[i])
-    }
+    api.users.read.config.should.include(read)
+    api.users.read.config.should.include(api.config)
   })
 })

--- a/src/__tests__/route.test.js
+++ b/src/__tests__/route.test.js
@@ -5,4 +5,19 @@ describe('route', function() {
   it ('can handle empty routes', function() {
     route(API({ baseURL: '' }))
   })
+
+  it ('extends each route with configuration settings', function() {
+    let api = API({
+      description: 'My API',
+      baseURL: 'http://example.com'
+    })
+
+    route(api, { users: { read: { path: 'users' } } })
+
+    api.users.read.config.should.have.property('path', 'users')
+
+    for (var i in api.config) {
+      api.users.read.config.should.have.property(i, api.config[i])
+    }
+  })
 })

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -13,8 +13,8 @@ let defaults = {
   onResponse : response => response.body
 }
 
-module.exports = function(routeConfig, apiConfig, requestConfig) {
-  let options = Object.assign({}, defaults, apiConfig, routeConfig, requestConfig)
+module.exports = function(routeConfig, requestConfig) {
+  let options = Object.assign({}, defaults, routeConfig, requestConfig)
 
   if ('mock' in options) {
     return Promise.resolve(options.mock)

--- a/src/route.js
+++ b/src/route.js
@@ -6,7 +6,9 @@ module.exports = function route(API, routes={}) {
 
     // For each endpoint (create, read, update, delete...)
     return remap(resource, function(options) {
-      return API.ajax.bind(null, API.config, options)
+      let config = Object.assign({}, API.config, options)
+
+      return Object.assign(API.ajax.bind(null, config), { config })
     })
   }, API)
 }


### PR DESCRIPTION
Name says it all:

```javascript
let api = API({
  description: 'My API',
  baseURL: 'http://example.com'
})

route(api, { users: { read: { path: 'users' } } })

api.users.read.config // => { description, baseURL, path }
```
