### PR TITLE
Allow Number 0 to be passed as a param

### DIFF
--- a/src/parameterizeRoute.js
+++ b/src/parameterizeRoute.js
@@ -12,6 +12,6 @@ module.exports = function (string, params={}) {
       throw TypeError(`"${key}" was not provided in the given params for ${string}`)
     }
 
-    return params[key] || ''
+    return params[key] !== undefined ? params[key] : ''
   })
 }


### PR DESCRIPTION
Feels on this @nhunzaker? Any reason params should *have* to be strings? I noticed you were doing that in the examples, but didn't see any documentation saying that you *must*.

```
API.users.read({ params: { id: 0 } })
```
The above currently fails, since `params[0]` evaluates to false.