### PR TITLE
Add concept of resourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ API.route({
   }
 })
 
+// this is equivalent to creating a create, read, update, and destroy
+// route. Options are folded into every route.
+API.resource("comments", { query: {} })
+
 // this will send a request to GET http://example.com/users
 API.users.read()
 

--- a/example/index.js
+++ b/example/index.js
@@ -7,13 +7,12 @@ var API = Gangway({
   }
 })
 
+API.resource("users")
+
 API.route({
-  users: {
-    read: {
-      method : 'GET',
-      path   : '/users/{user_id?}'
-    },
-    mock: { foo: 'bar' }
+  comments: {
+    method: "GET",
+    path: "/comments"
   }
 })
 

--- a/example/index.js
+++ b/example/index.js
@@ -11,8 +11,10 @@ API.resource("users")
 
 API.route({
   comments: {
-    method: "GET",
-    path: "/comments"
+    read: {
+      method: "GET",
+      path: "/comments"
+    }
   }
 })
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,6 @@
 var ajax  = require('./ajax')
 var route = require('./route')
+var resource = require('./resource')
 
 module.exports = function (config, routes) {
 
@@ -21,6 +22,10 @@ module.exports = function (config, routes) {
 
     route: function (routes) {
       return route(API, routes)
+    },
+
+    resource: function (routes, options) {
+      return resource(API, routes, options)
     }
 
   }

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,0 +1,28 @@
+var assign = require('./assign')
+
+module.exports = function resource (API, name, options) {
+  var route = {}
+
+  route[name] = {
+    create: assign({
+      method: 'POST',
+      path: name + '/{id}'
+    }, options),
+
+    read: assign({
+      path: name + '/{id}'
+    }, options),
+
+    update: assign({
+      method: 'PATCH',
+      path: name + '/{id}'
+    }, options),
+
+    destroy: assign({
+      method: 'DELETE',
+      path: name + '/{id}'
+    }, options)
+  }
+
+  return API.route(route)
+}

--- a/src/resource.js
+++ b/src/resource.js
@@ -4,24 +4,25 @@ module.exports = function resource (API, name, options) {
   var route = {}
 
   route[name] = {
-    create: assign({
+    create: assign(options, {
       method: 'POST',
       path: name + '/{id}'
-    }, options),
+    }),
 
-    read: assign({
+    read: assign(options, {
+      method: 'GET',
       path: name + '/{id}'
-    }, options),
+    }),
 
-    update: assign({
+    update: assign(options, {
       method: 'PATCH',
       path: name + '/{id}'
-    }, options),
+    }),
 
-    destroy: assign({
+    destroy: assign(options, {
       method: 'DELETE',
       path: name + '/{id}'
-    }, options)
+    })
   }
 
   return API.route(route)

--- a/src/resource.js
+++ b/src/resource.js
@@ -2,26 +2,27 @@ var assign = require('./assign')
 
 module.exports = function resource (API, name, options) {
   var route = {}
+  var path = name + '/{id}'
 
   route[name] = {
     create: assign(options, {
       method: 'POST',
-      path: name + '/{id}'
+      path: path
     }),
 
     read: assign(options, {
       method: 'GET',
-      path: name + '/{id}'
+      path: path
     }),
 
     update: assign(options, {
       method: 'PATCH',
-      path: name + '/{id}'
+      path: path
     }),
 
     destroy: assign(options, {
       method: 'DELETE',
-      path: name + '/{id}'
+      path: path
     })
   }
 

--- a/src/route.js
+++ b/src/route.js
@@ -1,10 +1,9 @@
 var remap   = require('./remap')
 var prepare = require('./prepare')
 
-module.exports = function route(API, routes) {
+module.exports = function route (API, routes) {
 
   return remap(routes || {}, function(resource) {
-
     // For each endpoint (create, read, update, delete...)
     return remap(resource, function(options) {
       var config = prepare(API.config, options)

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -33,13 +33,25 @@ describe('resource', function() {
     })
 
     context('and options are provided', function() {
-      api.resource('candy', { query: { sweet: true }})
+      api.resource('candy', {
+        method: 'POST',
+        path: 'bad',
+        query: { sweet: true }
+      })
 
       it ('assigns those options to routes', function() {
         assert.equal(api.candy.create.config.query.sweet, true)
         assert.equal(api.candy.read.config.query.sweet, true)
         assert.equal(api.candy.update.config.query.sweet, true)
         assert.equal(api.candy.destroy.config.query.sweet, true)
+      })
+
+      it ('never assigns options over the method attribute', function() {
+        assert.equal(api.candy.read.config.method, 'GET')
+      })
+
+      it ('never assigns options over the path attribute', function() {
+        assert.equal(api.candy.read.config.path, 'candy/{id}')
       })
     })
   })

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -1,0 +1,46 @@
+var API = require('../src/api')
+var route = require('../src/route')
+var assert = require('assert')
+
+describe('resource', function() {
+
+  context('when API.resource is invoked', function() {
+    var api = API({
+      description: 'My API',
+      baseURL: 'http://example.com'
+    })
+
+    api.resource('users')
+
+    it ('generates a create route', function() {
+      assert.equal(api.users.create.config.path, 'users/{id}')
+      assert.equal(api.users.create.config.method, 'POST')
+    })
+
+    it ('generates a read route', function() {
+      assert.equal(api.users.read.config.path, 'users/{id}')
+      assert.equal(api.users.read.config.method, 'GET')
+    })
+
+    it ('generates a update route', function() {
+      assert.equal(api.users.update.config.path, 'users/{id}')
+      assert.equal(api.users.update.config.method, 'PATCH')
+    })
+
+    it ('generates a destroy route', function() {
+      assert.equal(api.users.destroy.config.path, 'users/{id}')
+      assert.equal(api.users.destroy.config.method, 'DELETE')
+    })
+
+    context('and options are provided', function() {
+      api.resource('candy', { query: { sweet: true }})
+
+      it ('assigns those options to routes', function() {
+        assert.equal(api.candy.create.config.query.sweet, true)
+        assert.equal(api.candy.read.config.query.sweet, true)
+        assert.equal(api.candy.update.config.query.sweet, true)
+        assert.equal(api.candy.destroy.config.query.sweet, true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Instead of:

```javascript
API.route({
  comments: {
    create: {
      method: 'post',
      path: "/comments"
    },
    read: {
      method: 'get',
      path: "/comments/{id}"
    },
    update: {
      method: 'patch',
      path: "/comments/{id}"
    },
    destroy: {
      method: 'delete',
      path: "/comments/{id}"
    }
})
```

You can know do:

```javascript
API.resource('comments', options)
```