### PR TITLE
Add accept json header as default header

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -10,7 +10,9 @@ var DEFAULTS = {
   basePath   : '',
   body       : undefined,
   params     : undefined,
-  headers    : {},
+  headers    : {
+    'Accept': 'application/json'
+  },
   method     : 'GET',
   path       : '',
   query      : {},

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -31,6 +31,15 @@ describe('ajax', function() {
     })
   })
 
+  it ('automatically adds an Accept JSON header', function (done) {
+    ajax({
+      beforeSend(ajax) {
+        assert.equal(ajax.header.accept, 'application/json')
+        done()
+      }
+    })
+  })
+
   it ('can be mocked out', function(done) {
     ajax({
       baseURL : 'http://fizbuzz',


### PR DESCRIPTION
Adds an 'Accept': 'application/json' header to defaults.

cc @brianjlandau @mackermedia @greypants 

Fixes #26 