### PR TITLE
Nh remove promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,23 @@ opinions related to how we work.
 
 [![Circle CI](https://circleci.com/gh/vigetlabs/gangway.svg?style=svg&circle-token=d7c29c3bd61f3c3d671d1ba02841eb0c174d311a)](https://circleci.com/gh/vigetlabs/gangway)
 
-## Usage
+## Getting started
 
 Gangway is a factory function that progressively layers configuration
 options for building an AJAX request with `superagent`.
+
+All request methods return Promises. This means you'll need to include
+your own polyfill for Promise (depending on your environment). We
+recommend [`then/promise`](https://github.com/then/promise) as it
+includes additional methods like `.done()` and `.nodeify()` that
+improve interoperability and debugging:
+
+```
+require('promise/polyfill')
+// Continue with the rest of your code
+```
+
+Alternatively, provide `Promise` as a configuration option (see below).
 
 ### Create an instance of Gangway
 
@@ -105,6 +118,7 @@ beforeSend : Configure an instance of superagent before the request is sent
 onResponse : Run before resolving a request to preprocessing data
 onError    : Run before rejecting a request to preprocessing errors
 params     : Populate bindings in paths and are sent as request bodies. Defaults to body.
+Promise    : The Promise implementation. Defaults to global.Promise.
 path       : The path fragment of the endpoint, appended to baseURL
 type       : Content type, defaults to JSON
 query      : An object of query parameters. Gangway will automatically stringify this into the URL.

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,9 @@
-override:
-  - nvm use 0.12 && npm test
-  - nvm use 4.0 && npm test
-  - nvm use 5.0 && npm test
+machine:
+  node:
+    version: 5.7
+
+test:
+  override:
+    - nvm use 0.12 && npm test
+    - nvm use 4.3 && npm test
+    - nvm use 5.7 && npm test

--- a/circle.yml
+++ b/circle.yml
@@ -5,5 +5,5 @@ machine:
 test:
   override:
     - nvm use 0.12 && npm test
-    - nvm use 4.3 && npm test
-    - nvm use 5.7 && npm test
+    - nvm use 4 && npm test
+    - nvm use 5 && npm test

--- a/docs/guides/promises.md
+++ b/docs/guides/promises.md
@@ -2,8 +2,6 @@
 
 1. [Overview](#overview)
 2. [Promises in Gangway](#promises-in-gangway)
-3. [Using done() instead of then()](#using-done-instead-of-then)
-4. [Using nodeify for error-first callbacks](#using-nodeify-for-error-first-callbacks)
 
 ## Overview
 
@@ -14,10 +12,7 @@
 > [What is a promise?](https://www.promisejs.org#definition)
 
 For all endpoints created by Gangway, promises are returned to
-represent the
-request. [The usage of promises is well-documented](https://www.promisejs.org/),
-however in Gangway we have made some decisions that build on top of
-promises to support a better developer experience.
+represent the request.
 
 The examples for this guide will assume the following setup code:
 
@@ -33,15 +28,17 @@ API.namespace('users').route({
 
 ## Promises in Gangway
 
-Gangway uses the [then/promise](https://github.com/then/promise)
-implementation of Promises. This means that it follows the standard,
-A+ Promise specification:
-
 ```javascript
 API.users.read().then(handleSuccess, handleRejection).catch(handleError)
 ```
 
-## Using done() instead of then()
+Gangway does not include a Promise implementation, it is up to you to
+provide one. We recommended using the [then/promise](https://github.com/then/promise)
+implementation of Promises.
+
+Let's go into some reasons why.
+
+### Using done() instead of then() to prevent uncaught errors
 
 Promises are chainable. `then` can be called multiple times, layering
 on behaviors after a promise is resolved:
@@ -94,7 +91,7 @@ In a simple example, using `then` is typically fine. However the
 owness is on you to properly catch errors. `done` takes care of a lot
 of this work for you.
 
-## Using nodeify for error-first callbacks
+### Using nodeify for error-first callbacks
 
 [`then/promise`](https://github.com/then/promise) supports an
 additional set of methods: `nodeify` and `denodeify`. These methods

--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
     "url": "git://github.com/vigetlabs/gangway.git"
   },
   "dependencies": {
-    "promise": "~7.1",
     "superagent": "~1.7"
   },
   "devDependencies": {
-    "faux-jax": "https://github.com/algolia/faux-jax",
+    "faux-jax": "5.0.0",
     "istanbul": "0.4.2",
     "mocha": "2.4.5"
   }

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,5 +1,4 @@
 var Mock    = require('./mock')
-var Promise = require('promise')
 var Request = require('superagent')
 var prepare = require('./prepare')
 var url     = require('./url')
@@ -8,8 +7,12 @@ var assign  = require('./assign')
 module.exports = function AJAX (options) {
   options = prepare(options)
 
+  if (!options.Promise) {
+    throw TypeError('Gangway uses Promises. The current environment does not support them. Please include a Promise polyfill.')
+  }
+
   if ('mock' in options) {
-    return Mock(options)
+    return Promise.resolve(Mock(options))
   }
 
   var location = url(options.baseURL, url.resolve(options.basePath, options.path), assign({}, options.body, options.params))

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -12,7 +12,7 @@ module.exports = function AJAX (options) {
   }
 
   if ('mock' in options) {
-    return Promise.resolve(Mock(options))
+    return options.Promise.resolve(Mock(options))
   }
 
   var location = url(options.baseURL, url.resolve(options.basePath, options.path), assign({}, options.body, options.params))
@@ -25,7 +25,7 @@ module.exports = function AJAX (options) {
 
   options.beforeSend(message)
 
-  return new Promise(function(resolve, reject) {
+  return new options.Promise(function(resolve, reject) {
     message.end(function(err, response) {
       return err ? reject(options.onError(err)) : resolve(options.onResponse(response))
     })

--- a/src/mock.js
+++ b/src/mock.js
@@ -1,7 +1,3 @@
-var Promise = require('promise')
-
 module.exports = function (options) {
-  var reply = typeof options.mock === 'function' ? options.mock(options) : options.mock
-
-  return Promise.resolve(reply)
+  return typeof options.mock === 'function' ? options.mock(options) : options.mock
 }

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -19,7 +19,8 @@ var DEFAULTS = {
   type       : 'application/json',
   beforeSend : function(ajax) { return ajax },
   onResponse : function(response) { return response.body },
-  onError    : function(error) { return error }
+  onError    : function(error) { return error },
+  Promise    : global.Promise
 }
 
 module.exports = function prepare (/* options list */) {

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -8,7 +8,7 @@ describe('ajax', function() {
 
   before(function() {
     fauxJax.install()
-    fauxJax.on('request', function(request) {
+    fauxJax.on('request', function (request) {
       if (request.requestURL.match(/response\.json/)) {
         request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ "name" : "Gangway" }))
       } else {
@@ -25,10 +25,10 @@ describe('ajax', function() {
     ajax({
       baseURL : baseURL,
       path    : '/base/test/response.json'
-    }).done(function(body) {
+    }).then(function(body) {
       assert.equal(body.name, 'Gangway')
       done()
-    })
+    }).catch(done)
   })
 
   it ('automatically adds an Accept JSON header', function (done) {
@@ -46,10 +46,10 @@ describe('ajax', function() {
     ajax({
       baseURL : 'http://fizbuzz',
       mock    : 'fiz'
-    }).done(function(body) {
+    }).then(function(body) {
       assert.equal(body, 'fiz')
       done()
-    })
+    }).catch(done)
   })
 
   it ('the mocked value can be a function', function(done) {
@@ -61,40 +61,40 @@ describe('ajax', function() {
       }
     }
 
-    ajax(options).done(function(data) {
+    ajax(options).then(function(data) {
       assert.equal(data, 'yes')
       done()
-    })
+    }).catch(done)
   })
 
   it ('can override config', function(done) {
     ajax({
       baseURL : 'http://fizbuzz',
       mock    : 'fiz'
-    }).done(function(body) {
+    }).then(function(body) {
       assert.equal(body, 'fiz')
       done()
-    })
+    }).catch(done)
   })
 
   it ('can handle errors', function(done) {
     ajax({
       baseURL : baseURL,
       path    : '/asdf'
-    }).done(null, function(error) {
+    }).then(null, function(error) {
       assert.equal(error.status, 404)
       done()
-    })
+    }).catch(done)
   })
 
   it ('can operate as a promise a response', function(done) {
     ajax({
       baseURL : baseURL,
       path    : '/base/test/response.json'
-    }).done(function(data) {
+    }).then(function(data) {
       assert.equal(data.name, 'Gangway')
       done()
-    })
+    }).catch(done)
   })
 
   it ('can convert bindings using params', function(done) {
@@ -102,7 +102,7 @@ describe('ajax', function() {
       baseURL : baseURL,
       path    : '/base/test/{path}.json',
       params  : { path: 'response'}
-    }).nodeify(done)
+    }).then(function () { done() }, done)
   })
 
   it ('falls back on the `body` param if no params are given', function(done) {
@@ -110,14 +110,14 @@ describe('ajax', function() {
       baseURL : baseURL,
       path    : '/base/test/{path}.json',
       params  : { path: 'response' }
-    }).nodeify(done)
+    }).then(function () { done() }, done)
   })
 
   it ('can be converted into a node callback', function(done) {
     ajax({
       baseURL : baseURL,
       path    : '/base/test/response.json'
-    }).nodeify(done)
+    }).then(function () { done() }, done)
   })
 
   it ('can parse a response', function(done) {
@@ -127,7 +127,7 @@ describe('ajax', function() {
       onResponse: function (response) {
         assert(response instanceof superagent.Response)
       }
-    }).nodeify(done)
+    }).then(function () { done() }, done)
   })
 
   it ('can parse an error', function(done) {
@@ -138,7 +138,7 @@ describe('ajax', function() {
         assert(error instanceof Error)
         assert.equal(error.status, 404)
       }
-    }).nodeify(done)
+    }).then(function () { done() }, done)
   })
 
   it ('can preprocess a request', function(done) {
@@ -147,6 +147,25 @@ describe('ajax', function() {
       beforeSend: function (message) {
         assert(message instanceof superagent.Request)
       }
-    }).nodeify(done)
+    }).then(function () { done() }, done)
+  })
+
+  context('When Promise is not defined', function () {
+
+    beforeEach(function () {
+      this.Promise = global.Promise
+      global.Promise = null
+    })
+
+    afterEach(function () {
+      global.Promise = this.Promise
+    })
+
+    it ('throws an error', function () {
+      assert.throws(function () {
+        return ajax({})
+      }, /Please include a Promise polyfill/)
+    })
+
   })
 })

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -150,22 +150,21 @@ describe('ajax', function() {
     }).then(function () { done() }, done)
   })
 
-  context('When Promise is not defined', function () {
-
-    beforeEach(function () {
-      this.Promise = global.Promise
-      global.Promise = null
+  it ('accepts a custom Promise implimentation option', function(done) {
+    ajax({
+      Promise: {
+        resolve: function (value) {
+          assert.equal(value, 'test')
+          done()
+        }
+      },
+      mock: 'test'
     })
+  })
 
-    afterEach(function () {
-      global.Promise = this.Promise
-    })
-
-    it ('throws an error', function () {
-      assert.throws(function () {
-        return ajax({})
-      }, /Please include a Promise polyfill/)
-    })
-
+  it ('throws an error when promise is not defined', function () {
+    assert.throws(function () {
+      return ajax({ Promise: undefined })
+    }, /Please include a Promise polyfill/)
   })
 })


### PR DESCRIPTION
This PR removes `then/promise` in favor of allowing the end-user to define a Promise library. It also updates documentation to make recommendations on what Promise library to use.

Related to #31 