### PR TITLE
Paths should be relative

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -2,9 +2,24 @@ var parameterizeRoute  = require('./parameterizeRoute')
 var trimRight = /\/$/
 var trimLeft  = /^\//
 
+function isAbsolute (path) {
+  return (path || '').toString()[0] === '/'
+}
+
+function urlRoot (url) {
+  return url = url.replace(/\/\w+$/, '')
+}
+
 function resolve (base, path) {
-  base = (base || '').toString().replace(trimRight, '')
-  path = (path || '').toString().replace(trimLeft, '')
+  base = (base || '').toString()
+  path = (path || '').toString()
+
+  if (isAbsolute(path)) {
+    base = urlRoot(base)
+  }
+
+  base = base.replace(trimRight, '')
+  path = path.replace(trimLeft, '')
 
   return (base + '/' + path).replace(trimRight, '')
 }
@@ -14,5 +29,4 @@ function url (base, path, params) {
 }
 
 module.exports = url
-
 module.exports.resolve = resolve

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -127,7 +127,7 @@ describe('API()', function() {
 
     api.namespace('users').route({
       read: {
-        path: '/'
+        path: ''
       }
     })
 

--- a/test/url.test.js
+++ b/test/url.test.js
@@ -7,10 +7,6 @@ describe('url', function() {
     assert.equal(url('http://foobar.com/', 'path'), 'http://foobar.com/path')
   })
 
-  it ('trims path url left-handslashes', function() {
-    assert.equal(url('http://foobar.com', '/path'), 'http://foobar.com/path')
-  })
-
   it ('handles both base and path urls with slashes', function() {
     assert.equal(url('http://foobar.com', 'path'), 'http://foobar.com/path')
   })
@@ -29,4 +25,25 @@ describe('url', function() {
     var location = url('http://foobar.com', '/user/{id}', { id: 0 })
     assert.equal(location, 'http://foobar.com/user/0')
   })
+
+  context('when resolving URL segments', function () {
+    var samples = [
+      { base: '//foobar.com', path: '/path', expected: '//foobar.com/path' },
+      { base: 'http://foobar.com/fiz', path: '/path', expected: 'http://foobar.com/path' },
+      { base: 'http://foobar.biz.co/fiz', path: '/path', expected: 'http://foobar.biz.co/path' },
+      { base: 'http://foobar.biz.co/users', path: 'posts', expected: 'http://foobar.biz.co/users/posts' },
+      { base: '/fiz', path: '/path', expected: '/path' },
+      { base: '/foo', path: 'bar', expected: '/foo/bar' }
+    ]
+
+    samples.forEach(function (sample) {
+
+      context('for: ' + sample.base + ' + ' + sample.path, function () {
+        it ('correctly resolves the url', function() {
+          assert.equal(url(sample.base, sample.path), sample.expected)
+        })
+      })
+    })
+  })
+
 })


### PR DESCRIPTION
This PR adds relative path calculation such that the following configuration:

```javascript
var api = new Gangway({
    baseUrl: 'https://example.com/bar',
})

api.route({
    exceptionToRules: {
        path: '/deviant'
    }
})
```

Will send a request to `https://example.com/deviant`. Additionally:

```javascript
var api = new Gangway({
    baseUrl: 'https://example.com',
})

api.namespace('users').route({
    read: {
        path: '{id}'
    }
})
```

Would produce a request to `https://example.com/users/{id}`.

This should be more intuitive, and allow for more flexibility in path handling.