### PR TITLE
Dont merge body

### DIFF
--- a/src/prepare.js
+++ b/src/prepare.js
@@ -8,7 +8,6 @@ var toArray  = require('./toArray')
 var DEFAULTS = {
   baseURL    : '/',
   basePath   : '',
-  body       : undefined,
   params     : undefined,
   headers    : {
     'Accept': 'application/json'
@@ -31,7 +30,6 @@ module.exports = function prepare (/* options list */) {
   return options.reduce(function (memo, next) {
 
     return next ? assign(memo, next, {
-      body    : next.body ? assign(memo.body, next.body) : next.body,
       params  : assign(memo.params, next.params),
       query   : assign(memo.query, next.query),
       headers : assign(memo.headers, next.headers)

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -78,7 +78,7 @@ describe('API()', function() {
     assert.equal(endpoints.foo.config.query.two, 2)
   })
 
-  it ('folds together body params', function() {
+  it ('does not set default body params', function() {
     var endpoints = API({
       baseURL: baseURL,
       body: {
@@ -94,7 +94,7 @@ describe('API()', function() {
       }
     })
 
-    assert.equal(endpoints.foo.config.body.one, 1)
+    assert.equal(endpoints.foo.config.body.one, undefined)
     assert.equal(endpoints.foo.config.body.two, 2)
   })
 


### PR DESCRIPTION
Merging `body` with defaults was problematic since `body` is not always an object. For example, it might be `FormData`.

This removes `body` from the default configuration object, and always directly sends whatever `body` is sent.
